### PR TITLE
Fix LanceDB db_uri validation check

### DIFF
--- a/graphrag/config/models/graph_rag_config.py
+++ b/graphrag/config/models/graph_rag_config.py
@@ -295,7 +295,7 @@ class GraphRagConfig(BaseModel):
         """Validate the vector store configuration."""
         for store in self.vector_store.values():
             if store.type == VectorStoreType.LanceDB:
-                if not store.db_uri or store.db_uri.strip == "":
+                if not store.db_uri or store.db_uri.strip() == "":
                     msg = "Vector store URI is required for LanceDB. Please rerun `graphrag init` and set the vector store configuration."
                     raise ValueError(msg)
                 store.db_uri = str((Path(self.root_dir) / store.db_uri).resolve())


### PR DESCRIPTION
### Fix LanceDB [db_uri](cci:1://file:///c:/Users/T2430514/Downloads/graphrag/graphrag/config/models/graph_rag_config.py:293:4-300:82) validation check

The [_validate_vector_store_db_uri](cci:1://file:///c:/Users/T2430514/Downloads/graphrag/graphrag/config/models/graph_rag_config.py:293:4-300:82) method compared `store.db_uri.strip` (the method) to an empty string, which was always `False`.  
As a result, whitespace-only or empty [db_uri](cci:1://file:///c:/Users/T2430514/Downloads/graphrag/graphrag/config/models/graph_rag_config.py:293:4-300:82) values for LanceDB were silently accepted, leading to mis-configured vector-store paths and runtime failures when later resolving or connecting to the database.

This patch calls `strip()` before the comparison:

```python
if not store.db_uri or store.db_uri.strip() == "":
```
Now the validator correctly rejects blank or whitespace-only URIs, preventing invalid configurations from slipping through and improving overall robustness of the GraphRAG setup process.